### PR TITLE
Rename projection to projector

### DIFF
--- a/features/step_definitions/README.md
+++ b/features/step_definitions/README.md
@@ -17,6 +17,6 @@ In particular:
   * Imperative messages
   * This is how we represent "intent"
   * Access via external adapter (if connected)
-* `Then` steps can only consult *projections* (read models)
+* `Then` steps can only consult *projectors* (read models)
   * Query message
   * This is the only observable outcome

--- a/lib/Assembly.js
+++ b/lib/Assembly.js
@@ -1,17 +1,17 @@
 const MemoryEventStore = require('./cqrs-lite/eventstore/MemoryEventStore')
 const buildCommandBus = require('./cqrs-lite/buildCommandBus')
-const AccountProjection = require('./read/AccountProjection')
+const AccountProjector = require('./read/AccountProjector')
 const VotingPort = require('./VotingPort')
 
 module.exports = class Assembly {
   async start() {
     const eventStore = new MemoryEventStore()
-    const accountProjection = new AccountProjection()
+    const accountProjector = new AccountProjector()
     const commandBus = buildCommandBus(eventStore, [
-      accountProjection
+      accountProjector
     ])
 
-    this._votingPort = new VotingPort(commandBus, accountProjection)
+    this._votingPort = new VotingPort(commandBus, accountProjector)
   }
 
   async stop() {

--- a/lib/VotingPort.js
+++ b/lib/VotingPort.js
@@ -6,9 +6,9 @@ const {
 } = require('./domain/commands')
 
 module.exports = class VotingPort {
-  constructor(commandBus, accountProjection) {
+  constructor(commandBus, accountProjector) {
     this._commandBus = commandBus
-    this._accountProjection = accountProjection
+    this._accountProjector = accountProjector
     this._accountsByUid = new Map()
   }
 
@@ -18,7 +18,7 @@ module.exports = class VotingPort {
   }
 
   async creditAccount(accountName, amount) {
-    const account = this._accountProjection.getAccountByAccountName(accountName)
+    const account = this._accountProjector.getAccountByAccountName(accountName)
     await this._commandBus.dispatchCommand(new CreditAccountCommand({
       accountUid: account.uid,
       amount
@@ -26,12 +26,12 @@ module.exports = class VotingPort {
   }
 
   async transfer(fromAccountName, toAccountName, amount) {
-    const fromAccountUid = this._accountProjection.getAccountByAccountName(fromAccountName).uid
-    const toAccountUid = this._accountProjection.getAccountByAccountName(toAccountName).uid
+    const fromAccountUid = this._accountProjector.getAccountByAccountName(fromAccountName).uid
+    const toAccountUid = this._accountProjector.getAccountByAccountName(toAccountName).uid
     await this._commandBus.dispatchCommand(new TransferCommand({ fromAccountUid, toAccountUid, amount }))
   }
 
   async getAccount(accountName) {
-    return this._accountProjection.getAccountByAccountName(accountName)
+    return this._accountProjector.getAccountByAccountName(accountName)
   }
 }

--- a/lib/cqrs-lite/buildCommandBus.js
+++ b/lib/cqrs-lite/buildCommandBus.js
@@ -3,8 +3,8 @@ const Repository = require('./Repository')
 const EventDispatcher = require('./EventDispatcher')
 const DispatchingEventStore = require('./eventstore/DispatchingEventStore')
 
-module.exports = function buildCommandBus(eventStore, projections) {
-  const projectorEventDispatchers = projections.map(projection => new EventDispatcher(projection))
+module.exports = function buildCommandBus(eventStore, projectors) {
+  const projectorEventDispatchers = projectors.map(projector => new EventDispatcher(projector))
   const dispatchingEventStore = new DispatchingEventStore(eventStore, projectorEventDispatchers)
   const repository = new Repository(dispatchingEventStore)
   return new CommandBus(repository)

--- a/lib/read/AccountProjector.js
+++ b/lib/read/AccountProjector.js
@@ -1,4 +1,4 @@
-module.exports = class AccountProjection {
+module.exports = class AccountProjector {
   constructor() {
     this._accountsByAccountName = new Map()
     this._accountsByEntityUid = new Map()


### PR DESCRIPTION
Didn't _projections_ get renamed to _projectors_ universally in cucumber-pro? or did I miss a memo?